### PR TITLE
Fix CaveAir/minHeight and some others

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ version = "${mc_version}-${mod_version}"
 group = 'com.lothrazar.simpletomb'
 archivesBaseName = 'simpletomb'
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(16)
+java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 checkstyle {
     toolVersion '8.23'
@@ -35,7 +35,7 @@ checkstyleMain {
 }
 
 minecraft {
- mappings channel: 'official', version: '1.17.1'
+ mappings channel: 'official', version: '1.18.1'
     //makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
     // accessTransformer = file('build/resources/main/META-INF/accesstransformer.cfg')

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,9 @@ dist_folder=c:/temp
 curse_id=399669
 mod_version=1.0.9
 
-mc_version=1.17.1
-forge_version=37.1.1
+mc_version=1.18.1
+forge_version=39.0.5
 
 # optional dependencies
 #jei_version=jei-1.16.5:7.6.1.75
-curios_version=1.17.1-5.0.2.5
+curios_version=1.18.1-5.0.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,8 @@ curse_id=399669
 mod_version=1.0.9
 
 mc_version=1.17.1
-forge_version=37.0.13
+forge_version=37.1.1
 
 # optional dependencies
 #jei_version=jei-1.16.5:7.6.1.75
-curios_version=1.17.1-5.0.0.0
+curios_version=1.17.1-5.0.2.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.2-20210702220150+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/lothrazar/simpletomb/block/BlockTomb.java
+++ b/src/main/java/com/lothrazar/simpletomb/block/BlockTomb.java
@@ -28,7 +28,6 @@ import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.minecraftforge.common.ToolType;
 
 public class BlockTomb extends BaseEntityBlock {
 
@@ -62,11 +61,6 @@ public class BlockTomb extends BaseEntityBlock {
   @Override
   public String getDescriptionId() {
     return ModTomb.MODID + ".grave." + this.name;
-  }
-
-  @Override
-  public boolean isToolEffective(BlockState state, ToolType tool) {
-    return false;
   }
 
   @Override

--- a/src/main/java/com/lothrazar/simpletomb/block/TileEntityTomb.java
+++ b/src/main/java/com/lothrazar/simpletomb/block/TileEntityTomb.java
@@ -212,7 +212,7 @@ public class TileEntityTomb extends BlockEntity {
 
   @Override
   public ClientboundBlockEntityDataPacket getUpdatePacket() {
-    return new ClientboundBlockEntityDataPacket(this.worldPosition, 1, getUpdateTag());
+    return ClientboundBlockEntityDataPacket.create(this); // this.worldPosition, -1, getUpdateTag());
   }
 
   @Override

--- a/src/main/java/com/lothrazar/simpletomb/data/PlayerTombRecords.java
+++ b/src/main/java/com/lothrazar/simpletomb/data/PlayerTombRecords.java
@@ -9,7 +9,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.common.util.Constants;
+import net.minecraft.nbt.Tag;
 
 public class PlayerTombRecords {
 
@@ -33,7 +33,7 @@ public class PlayerTombRecords {
   public void read(CompoundTag data, UUID playerId) {
     this.playerId = playerId;
     if (data.contains(ModTomb.MODID)) {
-      ListTag glist = data.getList(ModTomb.MODID, Constants.NBT.TAG_COMPOUND);
+      ListTag glist = data.getList(ModTomb.MODID, Tag.TAG_COMPOUND);
       for (int i = 0; i < glist.size(); i++) {
         this.playerGraves.add(glist.getCompound(i));
       }

--- a/src/main/java/com/lothrazar/simpletomb/event/ClientEvents.java
+++ b/src/main/java/com/lothrazar/simpletomb/event/ClientEvents.java
@@ -22,7 +22,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ParticleFactoryRegisterEvent;
-import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.client.event.RenderLevelLastEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -40,7 +40,7 @@ public class ClientEvents {
   }
 
   @SubscribeEvent
-  public void render(RenderWorldLastEvent event) {
+  public void render(RenderLevelLastEvent event) {
     LocalPlayer player = Minecraft.getInstance().player;
     if (player != null && player.level != null) {
       ItemStack stack = player.getMainHandItem();
@@ -50,7 +50,7 @@ public class ClientEvents {
         if (location != null && !location.isOrigin() &&
             location.dim.equalsIgnoreCase(WorldHelper.dimensionToString(player.level)) &&
             player.level.isInWorldBounds(location.toBlockPos())) {
-          PoseStack poseStack = event.getMatrixStack();
+          PoseStack poseStack = event.getPoseStack();
           poseStack.pushPose();
           createBox(bufferSource, poseStack, location.x, location.y, location.z, 1.0F);
           poseStack.popPose();

--- a/src/main/java/com/lothrazar/simpletomb/helper/EntityHelper.java
+++ b/src/main/java/com/lothrazar/simpletomb/helper/EntityHelper.java
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ElytraItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraftforge.common.util.FakePlayer;
@@ -40,7 +41,7 @@ public class EntityHelper {
       }
       //
       if (player.getOffhandItem().isEmpty()) {
-        if (stack.getItem().isShield(stack, player)) { // && player.setSlot(99, stack.copy())) {
+        if (stack.getItem() == Items.SHIELD) { // stack.getItem().isShield(stack, player)) { // && player.setSlot(99, stack.copy())) {
           //          player.setItemInHand(InteractionHand.OFF_HAND, stack.copy());
           player.setItemSlot(EquipmentSlot.OFFHAND, stack.copy());
           //          player.getInventory().setItem(99, stack.copy());

--- a/src/main/java/com/lothrazar/simpletomb/helper/WorldHelper.java
+++ b/src/main/java/com/lothrazar/simpletomb/helper/WorldHelper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import com.lothrazar.simpletomb.ConfigTomb;
+import com.lothrazar.simpletomb.ModTomb;
 import com.lothrazar.simpletomb.data.LocationBlockPos;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
@@ -25,9 +26,9 @@ public class WorldHelper {
   }
 
   public static boolean isValidPlacement(Level world, BlockPos myPos) {
-    //0 is the bottom bedrock level
+    //MinBuildHeight varies by settings. (like datapack)
     //so if we place there, players cant place a block under it to stand safely
-    if (myPos.getY() < 1 || world.isOutsideBuildHeight(myPos)) {
+    if (myPos.getY() < world.getMinBuildHeight() + 1 || world.isOutsideBuildHeight(myPos)) {
       // blockstate doesnt matter, out of world
       return false;
     }

--- a/src/main/java/com/lothrazar/simpletomb/helper/WorldHelper.java
+++ b/src/main/java/com/lothrazar/simpletomb/helper/WorldHelper.java
@@ -32,9 +32,10 @@ public class WorldHelper {
       return false;
     }
     //    FluidState fluidHere = world.getFluidState(myPos);
+
     //only air or water. not any fluid state, and not any waterlogged block
     BlockState blockState = world.getBlockState(myPos);
-    return blockState.getBlock() == Blocks.AIR || blockState.getBlock() == Blocks.WATER; // && fluidHere.getFluid().isIn(FluidTags.WATER));
+    return blockState.getBlock() == Blocks.AIR || blockState.getBlock() == Blocks.CAVE_AIR || blockState.getBlock() == Blocks.WATER; // && fluidHere.getFluid().isIn(FluidTags.WATER));
   }
 
   public static LocationBlockPos findGraveSpawn(final Player player, final BlockPos initPos) {


### PR DESCRIPTION
501f529e60a01937915e3377eb891c4d4e4fe967 ~ 8237f327ab11264ecd1a5f26c07e7780edf8cda6
====
* Forge Updated to 1.17.1-37.1.1 which is about CVE-2021-44228
* Due to forge update, Remove ToolType related codes. But as strength of grave this doesn't affect anything. I think.
* Gradle updated to 7.3 as snapshot doesn't work anymore.
* Added to `CAVE_AIR` for generating grave cave air side correctly. Fix #4
* Use world#getMinBuildHeight to correctly find valid placement
  - This also applies some older version not just 1.18. As datapack can change this.
  
  
e5ab3ff7420016247f533641b5f1b1e2f2de0e7f
====
* Update dependencies for 1.18.1.
* Any other changes are related to forge or minecraft itself.

