### PR TITLE
Fix `invalidateCaps` calling `getBlockState`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     repositories {
-	 maven { url = 'https://maven.minecraftforge.net' }
-        maven { url = 'https://files.minecraftforge.net/maven' }
-        jcenter()
+        // These repositories are only for Gradle plugins, put any other repositories in the repository block further below
+        maven { url = 'https://maven.minecraftforge.net' }
         mavenCentral()
     }
     dependencies {
@@ -204,4 +203,8 @@ task copyJar(type: Copy) {
 
 cleanJar {
   delete 'build/libs'
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,11 +11,11 @@ curse_id=399669
 mod_version=1.0.13
 
 # Base info
-mc_version=1.18.1
-forge_version=39.0.88
+mc_version=1.18.2
+forge_version=40.1.0
 mcp_channel=official
-mcp_mappings=1.18.1
+mcp_mappings=1.18.2
 
 # optional dependencies
-jei_version=jei-1.18.1:9.2.1.69
-curios_version=1.18.1-5.0.6.0
+jei_version=jei-1.18.2:9.5.5.174
+curios_version=1.18.2-5.0.7.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/lothrazar/simpletomb/block/BlockEntityTomb.java
+++ b/src/main/java/com/lothrazar/simpletomb/block/BlockEntityTomb.java
@@ -80,6 +80,23 @@ public class BlockEntityTomb extends BlockEntity {
     }
   }
 
+  public void dropInventory(Level level, BlockPos pos) {
+    IItemHandler inventory = handler.orElse(null);
+    if (this.level != null && !this.level.isClientSide) {
+      for (int i = 0; i < inventory.getSlots(); ++i) {
+        ItemStack stack = inventory.getStackInSlot(i);
+        if (!stack.isEmpty()) {
+          Containers.dropItemStack(
+                  level,
+                  pos.getX(),
+                  pos.getY(),
+                  pos.getZ(),
+                  inventory.extractItem(i, stack.getCount(), false));
+        }
+      }
+    }
+  }
+
   public boolean onlyOwnersCanAccess() {
     return this.onlyOwnersAccess;
   }
@@ -180,23 +197,7 @@ public class BlockEntityTomb extends BlockEntity {
 
   @Override
   public void invalidateCaps() {
-    IItemHandler inventory = handler.orElse(null);
-    if (this.level != null && !this.level.isClientSide) {
-      if (this.level.getBlockState(this.worldPosition).getBlock() instanceof BlockTomb) {
-        return;
-      }
-      for (int i = 0; i < inventory.getSlots(); ++i) {
-        ItemStack stack = inventory.getStackInSlot(i);
-        if (!stack.isEmpty()) {
-          Containers.dropItemStack(
-              this.level,
-              this.worldPosition.getX(),
-              this.worldPosition.getY(),
-              this.worldPosition.getZ(),
-              inventory.extractItem(i, stack.getCount(), false));
-        }
-      }
-    }
+    handler.invalidate();
     super.invalidateCaps();
   }
 

--- a/src/main/java/com/lothrazar/simpletomb/block/BlockTomb.java
+++ b/src/main/java/com/lothrazar/simpletomb/block/BlockTomb.java
@@ -120,4 +120,16 @@ public class BlockTomb extends BaseEntityBlock {
       TombRegistry.GRAVE_KEY.get().removeKeyForGraveInInventory(player, new LocationBlockPos(pos, level));
     }
   }
+
+  @Override
+  public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
+    if (!state.is(newState.getBlock())) {
+      BlockEntity blockentity = level.getBlockEntity(pos);
+      if (blockentity instanceof BlockEntityTomb blockEntityTomb) {
+        blockEntityTomb.dropInventory(level, pos);
+      }
+
+      super.onRemove(state, level, pos, newState, isMoving);
+    }
+  }
 }


### PR DESCRIPTION
`invalidateCaps` is usually called when a chunk unloads which means calling `getBlockState` is a sure way to mess up chunk unloading.

What I can guess from the original code is that it meant to be called if the block somehow changes which a simple `onRemove` should do better. 